### PR TITLE
Removed duplicate permission warning

### DIFF
--- a/src/Libraries/Permission.cs
+++ b/src/Libraries/Permission.cs
@@ -214,7 +214,6 @@ namespace Umod.Libraries
 
                 if (PermissionExists(name))
                 {
-                    Interface.Umod.LogWarning("Duplicate permission registered '{0}' (by plugin '{1}')", name, owner.Title);
                     return;
                 }
 


### PR DESCRIPTION
Warning is really unnecessary